### PR TITLE
bugfix when server.properties is missing newline char

### DIFF
--- a/start-kafka.sh
+++ b/start-kafka.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# If server.properties is missing newline character at the end we add it to avoid continuing a line.
+if [ -f "$KAFKA_HOME/config/server.properties" ]; then
+    [ "$(tail -c 1 "$KAFKA_HOME/config/server.properties")" ] && echo "" >> "$KAFKA_HOME/config/server.properties"
+else
+    echo "WARNING: server.properties not found: $KAFKA_HOME/config/server.properties"
+fi
+
 if [[ -z "$KAFKA_PORT" ]]; then
     export KAFKA_PORT=9092
 fi


### PR DESCRIPTION
When server.properties is missing newline character in the last line of the file, kafka start script will append the first variable in the same last line of server properties, screwing 2 variables.
This happens for example with official kafka 0.11.0 release.

The fix is simply:
[ "$(tail -c 1 "$KAFKA_HOME/config/server.properties")" ] && echo "" >> "$KAFKA_HOME/config/server.properties"

To understand the error, just analyze what would happen with this:
echo "$kafka_name=${!env_var}" >> $KAFKA_HOME/config/server.properties

In a file that is missing newline character at the end. We append the text to the end of the last line, which probably already contains a variable definition, and not in a new line.